### PR TITLE
README: Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ import Component from '@ember/component';
 class ButtonComponent extends Component {}
 ```
 
-## Init vs Constructor
+### Init vs Constructor
 
 Although it was possible to use native classes before the RFCs, there were some
 subtle changes to behavior made to classes as part of the RFCs. Most notably,
@@ -78,7 +78,7 @@ during construction. The subtleties of these methods can be confusing, and as
 such, it is recommended that you continue to use `init` instead of `constructor`
 for any initialization code in your classes.
 
-## Class Fileds and Decorators
+### Class Fields and Decorators
 
 Note that this polyfill does _not_ enable the usage of class field or
 decorators, and does _not_ include any decorators. Ember has not yet added first


### PR DESCRIPTION
... and adjust heading level (`##` is h2, which is the same as `-----`, but this should have been h3)